### PR TITLE
Refactor money data type

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 	"github.com/zenfulcode/commercify/config"
+	"github.com/zenfulcode/commercify/internal/domain/money"
 	"github.com/zenfulcode/commercify/internal/infrastructure/database"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -423,7 +424,7 @@ func seedProducts(db *sql.DB) error {
 		_, err := db.Exec(
 			`INSERT INTO products (name, description, price, stock, category_id, seller_id, images, created_at, updated_at, product_number)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-			product.name, product.description, product.price, product.stock, categoryID, sellerID, product.images, now, now, productNumber,
+			product.name, product.description, money.ToCents(product.price), product.stock, categoryID, sellerID, product.images, now, now, productNumber,
 		)
 		if err != nil {
 			return err
@@ -636,8 +637,8 @@ func seedOrders(db *sql.DB) error {
 				orderID,
 				product.id,
 				quantity,
-				product.price,
-				subtotal,
+				int64(product.price),
+				int64(subtotal),
 				createdAt,
 			)
 
@@ -653,7 +654,7 @@ func seedOrders(db *sql.DB) error {
 			SET total_amount = $1
 			WHERE id = $2
 		`,
-			totalAmount,
+			int64(totalAmount),
 			orderID,
 		)
 
@@ -897,8 +898,8 @@ func seedDiscounts(db *sql.DB) error {
 			discount.discountType,
 			discount.method,
 			discount.value,
-			discount.minOrderValue,
-			discount.maxDiscountValue,
+			money.ToCents(discount.minOrderValue),
+			money.ToCents(discount.maxDiscountValue),
 			productIDsJSON,
 			categoryIDsJSON,
 			discount.startDate,

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -826,7 +826,7 @@ func seedDiscounts(db *sql.DB) error {
 			code:             "PRODUCT10OFF",
 			discountType:     "product",
 			method:           "fixed",
-			value:            10.0,
+			value:            100.0,
 			minOrderValue:    0,
 			maxDiscountValue: 0,
 			productIDs:       productIDs[2:], // Use remaining products

--- a/internal/application/usecase/discount_usecase_test.go
+++ b/internal/application/usecase/discount_usecase_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zenfulcode/commercify/internal/application/usecase"
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/money"
 	"github.com/zenfulcode/commercify/testutil/mock"
 )
 
@@ -53,8 +54,8 @@ func TestDiscountUseCase_CreateDiscount(t *testing.T) {
 		assert.Equal(t, entity.DiscountTypeBasket, discount.Type)
 		assert.Equal(t, entity.DiscountMethodPercentage, discount.Method)
 		assert.Equal(t, input.Value, discount.Value)
-		assert.Equal(t, input.MinOrderValue, discount.MinOrderValue)
-		assert.Equal(t, input.MaxDiscountValue, discount.MaxDiscountValue)
+		assert.Equal(t, money.ToCents(input.MinOrderValue), discount.MinOrderValue)
+		assert.Equal(t, money.ToCents(input.MaxDiscountValue), discount.MaxDiscountValue)
 		assert.Equal(t, input.UsageLimit, discount.UsageLimit)
 		assert.Equal(t, 0, discount.CurrentUsage)
 		assert.True(t, discount.Active)
@@ -347,12 +348,12 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		product1 := &entity.Product{
 			ID:    1,
 			Name:  "Premium Headphones",
-			Price: 200.0,
+			Price: money.ToCents(200.0),
 		}
 		product2 := &entity.Product{
 			ID:    2,
 			Name:  "Budget Headphones",
-			Price: 50.0,
+			Price: money.ToCents(50.0),
 		}
 		productRepo.Create(product1)
 		productRepo.Create(product2)
@@ -406,12 +407,12 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		product1 := &entity.Product{
 			ID:    1,
 			Name:  "Premium Headphones",
-			Price: 200.0,
+			Price: money.ToCents(200.0),
 		}
 		product2 := &entity.Product{
 			ID:    2,
 			Name:  "Budget Headphones",
-			Price: 50.0,
+			Price: money.ToCents(50.0),
 		}
 		productRepo.Create(product1)
 		productRepo.Create(product2)
@@ -437,14 +438,14 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 			{
 				ProductID: 1, // Premium Headphones with discount
 				Quantity:  2,
-				Price:     200.0,
-				Subtotal:  400.0,
+				Price:     money.ToCents(200.0),
+				Subtotal:  money.ToCents(400.0),
 			},
 			{
 				ProductID: 2, // Budget Headphones without discount
 				Quantity:  1,
-				Price:     50.0,
-				Subtotal:  50.0,
+				Price:     money.ToCents(50.0),
+				Subtotal:  money.ToCents(50.0),
 			},
 		}
 
@@ -477,13 +478,13 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedOrder)
 		// Fixed discount of $20 is applied once to the product (not per quantity)
-		assert.Equal(t, 20.0, updatedOrder.DiscountAmount)
+		assert.Equal(t, money.ToCents(20.0), updatedOrder.DiscountAmount)
 		// Total is $450, discount is $20, so final amount should be $430
-		assert.Equal(t, 430.0, updatedOrder.FinalAmount)
+		assert.Equal(t, money.ToCents(430.0), updatedOrder.FinalAmount)
 		assert.NotNil(t, updatedOrder.AppliedDiscount)
 		assert.Equal(t, discount.ID, updatedOrder.AppliedDiscount.DiscountID)
 		assert.Equal(t, discount.Code, updatedOrder.AppliedDiscount.DiscountCode)
-		assert.Equal(t, 20.0, updatedOrder.AppliedDiscount.DiscountAmount)
+		assert.Equal(t, money.ToCents(20.0), updatedOrder.AppliedDiscount.DiscountAmount)
 	})
 
 	t.Run("Apply product-specific percentage discount to order", func(t *testing.T) {
@@ -497,12 +498,12 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		product1 := &entity.Product{
 			ID:    1,
 			Name:  "Premium Headphones",
-			Price: 200.0,
+			Price: money.ToCents(200.0),
 		}
 		product2 := &entity.Product{
 			ID:    2,
 			Name:  "Budget Headphones",
-			Price: 50.0,
+			Price: money.ToCents(50.0),
 		}
 		productRepo.Create(product1)
 		productRepo.Create(product2)
@@ -528,14 +529,14 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 			{
 				ProductID: 1, // Premium Headphones with discount
 				Quantity:  2,
-				Price:     200.0,
-				Subtotal:  400.0,
+				Price:     money.ToCents(200.0),
+				Subtotal:  money.ToCents(400.0),
 			},
 			{
 				ProductID: 2, // Budget Headphones without discount
 				Quantity:  1,
-				Price:     50.0,
-				Subtotal:  50.0,
+				Price:     money.ToCents(50.0),
+				Subtotal:  money.ToCents(50.0),
 			},
 		}
 
@@ -568,13 +569,13 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedOrder)
 		// 10% of Premium Headphones total (10% of $400) = $40
-		assert.Equal(t, 40.0, updatedOrder.DiscountAmount)
+		assert.Equal(t, money.ToCents(40.0), updatedOrder.DiscountAmount)
 		// Total is $450, discount is $40, so final amount should be $410
-		assert.Equal(t, 410.0, updatedOrder.FinalAmount)
+		assert.Equal(t, money.ToCents(410.0), updatedOrder.FinalAmount)
 		assert.NotNil(t, updatedOrder.AppliedDiscount)
 		assert.Equal(t, discount.ID, updatedOrder.AppliedDiscount.DiscountID)
 		assert.Equal(t, discount.Code, updatedOrder.AppliedDiscount.DiscountCode)
-		assert.Equal(t, 40.0, updatedOrder.AppliedDiscount.DiscountAmount)
+		assert.Equal(t, money.ToCents(40.0), updatedOrder.AppliedDiscount.DiscountAmount)
 	})
 
 	t.Run("Apply product-specific discount with maximum discount cap", func(t *testing.T) {
@@ -588,12 +589,12 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		product1 := &entity.Product{
 			ID:    1,
 			Name:  "Premium Headphones",
-			Price: 200.0,
+			Price: money.ToCents(200.0),
 		}
 		product2 := &entity.Product{
 			ID:    2,
 			Name:  "Budget Headphones",
-			Price: 50.0,
+			Price: money.ToCents(50.0),
 		}
 		productRepo.Create(product1)
 		productRepo.Create(product2)
@@ -605,8 +606,8 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 			entity.DiscountMethodPercentage,
 			25.0,
 			0,
-			30.0,         // Maximum discount of $30
-			[]uint{1, 2}, // Apply to both Premium and Budget Headphones
+			money.ToCents(30.0), // Maximum discount of $30
+			[]uint{1, 2},        // Apply to both Premium and Budget Headphones
 			[]uint{},
 			time.Now().Add(-24*time.Hour),
 			time.Now().Add(30*24*time.Hour),
@@ -619,14 +620,14 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 			{
 				ProductID: 1, // Premium Headphones
 				Quantity:  1,
-				Price:     200.0,
-				Subtotal:  200.0,
+				Price:     money.ToCents(200.0),
+				Subtotal:  money.ToCents(200.0),
 			},
 			{
 				ProductID: 2, // Budget Headphones
 				Quantity:  1,
-				Price:     50.0,
-				Subtotal:  50.0,
+				Price:     money.ToCents(50.0),
+				Subtotal:  money.ToCents(50.0),
 			},
 		}
 
@@ -659,13 +660,13 @@ func TestDiscountUseCase_ProductSpecificDiscount(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedOrder)
 		// 25% of ($200 + $50) = $62.50, but capped at $30
-		assert.Equal(t, 30.0, updatedOrder.DiscountAmount)
+		assert.Equal(t, money.ToCents(30.0), updatedOrder.DiscountAmount)
 		// Total is $250, discount is $30, so final amount should be $220
-		assert.Equal(t, 220.0, updatedOrder.FinalAmount)
+		assert.Equal(t, money.ToCents(220.0), updatedOrder.FinalAmount)
 		assert.NotNil(t, updatedOrder.AppliedDiscount)
 		assert.Equal(t, discount.ID, updatedOrder.AppliedDiscount.DiscountID)
 		assert.Equal(t, discount.Code, updatedOrder.AppliedDiscount.DiscountCode)
-		assert.Equal(t, 30.0, updatedOrder.AppliedDiscount.DiscountAmount)
+		assert.Equal(t, money.ToCents(30.0), updatedOrder.AppliedDiscount.DiscountAmount)
 	})
 }
 
@@ -848,8 +849,8 @@ func TestDiscountUseCase_UpdateDiscount(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, input.Code, updatedDiscount.Code)
 		assert.Equal(t, input.Value, updatedDiscount.Value)
-		assert.Equal(t, input.MinOrderValue, updatedDiscount.MinOrderValue)
-		assert.Equal(t, input.MaxDiscountValue, updatedDiscount.MaxDiscountValue)
+		assert.Equal(t, money.ToCents(input.MinOrderValue), updatedDiscount.MinOrderValue)
+		assert.Equal(t, money.ToCents(input.MaxDiscountValue), updatedDiscount.MaxDiscountValue)
 		assert.Equal(t, input.UsageLimit, updatedDiscount.UsageLimit)
 		assert.Equal(t, input.Active, updatedDiscount.Active)
 	})
@@ -1120,14 +1121,14 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 			{
 				ProductID: 1,
 				Quantity:  2,
-				Price:     50.0,
-				Subtotal:  100.0,
+				Price:     5000,
+				Subtotal:  10000,
 			},
 			{
 				ProductID: 2,
 				Quantity:  1,
-				Price:     10.0,
-				Subtotal:  10.0,
+				Price:     1000,
+				Subtotal:  1000,
 			},
 		}
 
@@ -1159,12 +1160,12 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		// Assert
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedOrder)
-		assert.Equal(t, 11.0, updatedOrder.DiscountAmount) // 10% of 110 = 11
-		assert.Equal(t, 99.0, updatedOrder.FinalAmount)    // 110 - 11 = 10
+		assert.Equal(t, money.ToCents(11.0), updatedOrder.DiscountAmount) // 10% of 110 = 11
+		assert.Equal(t, money.ToCents(99.0), updatedOrder.FinalAmount)    // 110 - 11 = 10
 		assert.NotNil(t, updatedOrder.AppliedDiscount)
 		assert.Equal(t, discount.ID, updatedOrder.AppliedDiscount.DiscountID)
 		assert.Equal(t, discount.Code, updatedOrder.AppliedDiscount.DiscountCode)
-		assert.Equal(t, 11.0, updatedOrder.AppliedDiscount.DiscountAmount)
+		assert.Equal(t, money.ToCents(11.0), updatedOrder.AppliedDiscount.DiscountAmount)
 	})
 
 	t.Run("Apply category-specific discount to order", func(t *testing.T) {
@@ -1214,7 +1215,7 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		discountRepo.Create(discount)
 
 		// Set up product repo mock search behavior
-		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error) {
+		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
 			if categoryID == 1 {
 				return []*entity.Product{product1, product2}, nil
 			}
@@ -1226,20 +1227,20 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 			{
 				ProductID: 1, // Phone (in Electronics category)
 				Quantity:  1,
-				Price:     100.0,
-				Subtotal:  100.0,
+				Price:     10000,
+				Subtotal:  10000,
 			},
 			{
 				ProductID: 2, // Laptop (in Electronics category)
 				Quantity:  1,
-				Price:     1000.0,
-				Subtotal:  1000.0,
+				Price:     100000,
+				Subtotal:  100000,
 			},
 			{
 				ProductID: 3, // Some other product not in Electronics
 				Quantity:  1,
-				Price:     50.0,
-				Subtotal:  50.0,
+				Price:     5000,
+				Subtotal:  5000,
 			},
 		}
 
@@ -1273,13 +1274,13 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 		assert.NotNil(t, updatedOrder)
 		// Should apply 25% discount to the products in Electronics category
 		// 25% of (100 + 1000) = 275
-		assert.Equal(t, 275.0, updatedOrder.DiscountAmount)
+		assert.Equal(t, money.ToCents(275.0), updatedOrder.DiscountAmount)
 		// Final amount should be: 100 + 1000 + 50 - 275 = 875
-		assert.Equal(t, 875.0, updatedOrder.FinalAmount)
+		assert.Equal(t, money.ToCents(875.0), updatedOrder.FinalAmount)
 		assert.NotNil(t, updatedOrder.AppliedDiscount)
 		assert.Equal(t, discount.ID, updatedOrder.AppliedDiscount.DiscountID)
 		assert.Equal(t, discount.Code, updatedOrder.AppliedDiscount.DiscountCode)
-		assert.Equal(t, 275.0, updatedOrder.AppliedDiscount.DiscountAmount)
+		assert.Equal(t, money.ToCents(275.0), updatedOrder.AppliedDiscount.DiscountAmount)
 	})
 
 	t.Run("Apply invalid discount code", func(t *testing.T) {
@@ -1294,8 +1295,8 @@ func TestDiscountUseCase_ApplyDiscountToOrder(t *testing.T) {
 			{
 				ProductID: 1,
 				Quantity:  2,
-				Price:     50.0,
-				Subtotal:  100.0,
+				Price:     5000,
+				Subtotal:  10000,
 			},
 		}
 
@@ -1360,8 +1361,8 @@ func TestDiscountUseCase_RemoveDiscountFromOrder(t *testing.T) {
 			{
 				ProductID: 1,
 				Quantity:  2,
-				Price:     50.0,
-				Subtotal:  100.0,
+				Price:     5000,
+				Subtotal:  1000,
 			},
 		}
 
@@ -1375,7 +1376,7 @@ func TestDiscountUseCase_RemoveDiscountFromOrder(t *testing.T) {
 		// Apply discount manually
 		order.ApplyDiscount(discount)
 		assert.NotNil(t, order.AppliedDiscount)
-		assert.Greater(t, order.DiscountAmount, 0.0)
+		assert.Greater(t, order.DiscountAmount, money.ToCents(0.0))
 		assert.Less(t, order.FinalAmount, order.TotalAmount)
 
 		// Create use case with mocks

--- a/internal/application/usecase/product_usecase_test.go
+++ b/internal/application/usecase/product_usecase_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zenfulcode/commercify/internal/application/usecase"
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/money"
 	"github.com/zenfulcode/commercify/testutil/mock"
 )
 
@@ -50,7 +51,7 @@ func TestProductUseCase_CreateProduct(t *testing.T) {
 		assert.NotNil(t, product)
 		assert.Equal(t, input.Name, product.Name)
 		assert.Equal(t, input.Description, product.Description)
-		assert.Equal(t, input.Price, product.Price)
+		assert.Equal(t, money.ToCents(input.Price), product.Price)
 		assert.Equal(t, input.Stock, product.Stock)
 		assert.Equal(t, input.CategoryID, product.CategoryID)
 		assert.Equal(t, input.SellerID, product.SellerID)
@@ -124,7 +125,7 @@ func TestProductUseCase_CreateProduct(t *testing.T) {
 		assert.Equal(t, "SKU-1", product.Variants[0].SKU)
 		assert.Equal(t, true, product.Variants[0].IsDefault)
 		assert.Equal(t, "SKU-2", product.Variants[1].SKU)
-		assert.Equal(t, 129.99, product.Variants[1].ComparePrice)
+		assert.Equal(t, money.ToCents(129.99), product.Variants[1].ComparePrice)
 	})
 
 	t.Run("Create product with invalid category", func(t *testing.T) {
@@ -279,7 +280,7 @@ func TestProductUseCase_UpdateProduct(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, input.Name, updatedProduct.Name)
 		assert.Equal(t, input.Description, updatedProduct.Description)
-		assert.Equal(t, input.Price, updatedProduct.Price)
+		assert.Equal(t, money.ToCents(input.Price), updatedProduct.Price)
 		assert.Equal(t, input.Stock, updatedProduct.Stock)
 		assert.Equal(t, input.CategoryID, updatedProduct.CategoryID)
 		assert.Equal(t, input.Images, updatedProduct.Images)
@@ -375,8 +376,8 @@ func TestProductUseCase_AddVariant(t *testing.T) {
 		assert.NotNil(t, variant)
 		assert.Equal(t, input.ProductID, variant.ProductID)
 		assert.Equal(t, input.SKU, variant.SKU)
-		assert.Equal(t, input.Price, variant.Price)
-		assert.Equal(t, input.ComparePrice, variant.ComparePrice)
+		assert.Equal(t, money.ToCents(input.Price), variant.Price)
+		assert.Equal(t, money.ToCents(input.ComparePrice), variant.ComparePrice)
 		assert.Equal(t, input.Stock, variant.Stock)
 		assert.Equal(t, input.Attributes, variant.Attributes)
 		assert.Equal(t, input.Images, variant.Images)
@@ -385,7 +386,7 @@ func TestProductUseCase_AddVariant(t *testing.T) {
 		// Check that product is updated
 		updatedProduct, _ := productRepo.GetByID(1)
 		assert.True(t, updatedProduct.HasVariants)
-		assert.Equal(t, input.Price, updatedProduct.Price) // Price should be updated from default variant
+		assert.Equal(t, money.ToCents(input.Price), updatedProduct.Price) // Price should be updated from default variant
 	})
 }
 
@@ -463,8 +464,8 @@ func TestProductUseCase_UpdateVariant(t *testing.T) {
 		// Assert
 		assert.NoError(t, err)
 		assert.Equal(t, input.SKU, updatedVariant.SKU)
-		assert.Equal(t, input.Price, updatedVariant.Price)
-		assert.Equal(t, input.ComparePrice, updatedVariant.ComparePrice)
+		assert.Equal(t, money.ToCents(input.Price), updatedVariant.Price)
+		assert.Equal(t, money.ToCents(input.ComparePrice), updatedVariant.ComparePrice)
 		assert.Equal(t, input.Stock, updatedVariant.Stock)
 		assert.Equal(t, input.Attributes, updatedVariant.Attributes)
 		assert.Equal(t, input.Images, updatedVariant.Images)
@@ -476,7 +477,7 @@ func TestProductUseCase_UpdateVariant(t *testing.T) {
 
 		// Check that product price is updated
 		updatedProduct, _ := productRepo.GetByID(1)
-		assert.Equal(t, input.Price, updatedProduct.Price)
+		assert.Equal(t, money.ToCents(input.Price), updatedProduct.Price)
 	})
 }
 

--- a/internal/application/usecase/product_usecase_test.go
+++ b/internal/application/usecase/product_usecase_test.go
@@ -174,7 +174,7 @@ func TestProductUseCase_GetProductByID(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -246,7 +246,7 @@ func TestProductUseCase_UpdateProduct(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -266,7 +266,7 @@ func TestProductUseCase_UpdateProduct(t *testing.T) {
 		input := usecase.UpdateProductInput{
 			Name:        "Updated Product",
 			Description: "Updated description",
-			Price:       129.99,
+			Price:       12999,
 			Stock:       50,
 			CategoryID:  2,
 			Images:      []string{"updated.jpg"},
@@ -296,7 +296,7 @@ func TestProductUseCase_UpdateProduct(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -339,7 +339,7 @@ func TestProductUseCase_AddVariant(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -401,7 +401,7 @@ func TestProductUseCase_UpdateVariant(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -415,7 +415,7 @@ func TestProductUseCase_UpdateVariant(t *testing.T) {
 			ID:        1,
 			ProductID: 1,
 			SKU:       "SKU-1",
-			Price:     99.99,
+			Price:     9999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Red"},
@@ -429,7 +429,7 @@ func TestProductUseCase_UpdateVariant(t *testing.T) {
 			ID:        2,
 			ProductID: 1,
 			SKU:       "SKU-2",
-			Price:     109.99,
+			Price:     10999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Blue"},
@@ -492,7 +492,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -506,7 +506,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:        1,
 			ProductID: 1,
 			SKU:       "SKU-1",
-			Price:     99.99,
+			Price:     9999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Red"},
@@ -520,7 +520,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:        2,
 			ProductID: 1,
 			SKU:       "SKU-2",
-			Price:     109.99,
+			Price:     10999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Blue"},
@@ -565,7 +565,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -579,7 +579,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:        1,
 			ProductID: 1,
 			SKU:       "SKU-1",
-			Price:     99.99,
+			Price:     9999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Red"},
@@ -593,7 +593,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:        2,
 			ProductID: 1,
 			SKU:       "SKU-2",
-			Price:     109.99,
+			Price:     10999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Blue"},
@@ -637,7 +637,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -651,7 +651,7 @@ func TestProductUseCase_DeleteVariant(t *testing.T) {
 			ID:        1,
 			ProductID: 1,
 			SKU:       "SKU-1",
-			Price:     99.99,
+			Price:     9999,
 			Stock:     50,
 			Attributes: []entity.VariantAttribute{
 				{Name: "Color", Value: "Red"},
@@ -689,7 +689,7 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			ID:          1,
 			Name:        "Blue Shirt",
 			Description: "A nice blue shirt",
-			Price:       29.99,
+			Price:       2999,
 			CategoryID:  1,
 			SellerID:    1,
 		}
@@ -699,7 +699,7 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			ID:          2,
 			Name:        "Red T-shirt",
 			Description: "A comfortable red t-shirt",
-			Price:       19.99,
+			Price:       1999,
 			CategoryID:  1,
 			SellerID:    1,
 		}
@@ -709,14 +709,14 @@ func TestProductUseCase_SearchProducts(t *testing.T) {
 			ID:          3,
 			Name:        "Black Jeans",
 			Description: "Stylish black jeans",
-			Price:       49.99,
+			Price:       4999,
 			CategoryID:  2,
 			SellerID:    2,
 		}
 		productRepo.Create(product3)
 
 		// Configure mock search function
-		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error) {
+		productRepo.MockSearch = func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
 			results := make([]*entity.Product, 0)
 
 			// Simple implementation that checks if query is in name or description
@@ -822,7 +822,7 @@ func TestProductUseCase_DeleteProduct(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,
@@ -861,7 +861,7 @@ func TestProductUseCase_DeleteProduct(t *testing.T) {
 			ID:          1,
 			Name:        "Test Product",
 			Description: "This is a test product",
-			Price:       99.99,
+			Price:       9999,
 			Stock:       100,
 			CategoryID:  1,
 			SellerID:    1,

--- a/internal/domain/entity/payment_transaction.go
+++ b/internal/domain/entity/payment_transaction.go
@@ -30,7 +30,7 @@ type PaymentTransaction struct {
 	TransactionID string            // External transaction ID from payment provider
 	Type          TransactionType   // Type of transaction (authorize, capture, refund, cancel)
 	Status        TransactionStatus // Status of the transaction
-	Amount        float64           // Amount of the transaction
+	Amount        int64             // Amount of the transaction
 	Currency      string            // Currency of the transaction
 	Provider      string            // Payment provider (stripe, paypal, etc.)
 	RawResponse   string            // Raw response from payment provider (JSON)
@@ -45,7 +45,7 @@ func NewPaymentTransaction(
 	transactionID string,
 	transactionType TransactionType,
 	status TransactionStatus,
-	amount float64,
+	amount int64,
 	currency string,
 	provider string,
 ) (*PaymentTransaction, error) {

--- a/internal/domain/entity/product.go
+++ b/internal/domain/entity/product.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/zenfulcode/commercify/internal/domain/money"
 )
 
 // Product represents a product in the system
@@ -12,7 +14,7 @@ type Product struct {
 	ProductNumber string            `json:"product_number"`
 	Name          string            `json:"name"`
 	Description   string            `json:"description"`
-	Price         float64           `json:"price"`
+	Price         int64             `json:"price"` // Stored as cents
 	Stock         int               `json:"stock"`
 	Weight        float64           `json:"weight"` // Weight in kg
 	CategoryID    uint              `json:"category_id"`
@@ -24,12 +26,12 @@ type Product struct {
 	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
-// NewProduct creates a new product with the given details
-func NewProduct(name, description string, price float64, stock int, weight float64, categoryID, sellerID uint, images []string) (*Product, error) {
+// NewProduct creates a new product with the given details (price in cents)
+func NewProduct(name, description string, price int64, stock int, weight float64, categoryID, sellerID uint, images []string) (*Product, error) {
 	if name == "" {
 		return nil, errors.New("product name cannot be empty")
 	}
-	if price <= 0 {
+	if price <= 0 { // Check cents
 		return nil, errors.New("price must be greater than zero")
 	}
 	if stock < 0 {
@@ -48,7 +50,7 @@ func NewProduct(name, description string, price float64, stock int, weight float
 		Name:          name,
 		ProductNumber: productNumber,
 		Description:   description,
-		Price:         price,
+		Price:         price, // Already in cents
 		Stock:         stock,
 		Weight:        weight,
 		CategoryID:    categoryID,
@@ -165,6 +167,11 @@ func (p *Product) GetTotalWeight(quantity int) float64 {
 		return 0
 	}
 	return p.Weight * float64(quantity)
+}
+
+// GetPriceDollars returns the price in dollars
+func (p *Product) GetPriceDollars() float64 {
+	return money.FromCents(p.Price)
 }
 
 // Category represents a product category

--- a/internal/domain/entity/shipping_rate.go
+++ b/internal/domain/entity/shipping_rate.go
@@ -57,7 +57,7 @@ type ShippingOption struct {
 
 // NewShippingRate creates a new shipping rate
 func NewShippingRate(
-	shippingMethodID,
+	shippingMethodID uint,
 	shippingZoneID uint,
 	baseRate,
 	minOrderValue int64,

--- a/internal/domain/entity/shipping_rate.go
+++ b/internal/domain/entity/shipping_rate.go
@@ -12,9 +12,9 @@ type ShippingRate struct {
 	ShippingMethod        *ShippingMethod   `json:"shipping_method,omitempty"`
 	ShippingZoneID        uint              `json:"shipping_zone_id"`
 	ShippingZone          *ShippingZone     `json:"shipping_zone,omitempty"`
-	BaseRate              float64           `json:"base_rate"`
-	MinOrderValue         float64           `json:"min_order_value"`
-	FreeShippingThreshold *float64          `json:"free_shipping_threshold"`
+	BaseRate              int64             `json:"base_rate"`
+	MinOrderValue         int64             `json:"min_order_value"`
+	FreeShippingThreshold *int64            `json:"free_shipping_threshold"`
 	WeightBasedRates      []WeightBasedRate `json:"weight_based_rates,omitempty"`
 	ValueBasedRates       []ValueBasedRate  `json:"value_based_rates,omitempty"`
 	Active                bool              `json:"active"`
@@ -28,7 +28,7 @@ type WeightBasedRate struct {
 	ShippingRateID uint      `json:"shipping_rate_id"`
 	MinWeight      float64   `json:"min_weight"`
 	MaxWeight      float64   `json:"max_weight"`
-	Rate           float64   `json:"rate"` // Can be flat fee or percentage
+	Rate           int64     `json:"rate"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }
@@ -37,30 +37,30 @@ type WeightBasedRate struct {
 type ValueBasedRate struct {
 	ID             uint      `json:"id"`
 	ShippingRateID uint      `json:"shipping_rate_id"`
-	MinOrderValue  float64   `json:"min_order_value"`
-	MaxOrderValue  float64   `json:"max_order_value"`
-	Rate           float64   `json:"rate"` // Can be flat fee or percentage
+	MinOrderValue  int64     `json:"min_order_value"`
+	MaxOrderValue  int64     `json:"max_order_value"`
+	Rate           int64     `json:"rate"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // ShippingOption represents a single shipping option with its cost
 type ShippingOption struct {
-	ShippingRateID        uint    `json:"shipping_rate_id"`
-	ShippingMethodID      uint    `json:"shipping_method_id"`
-	Name                  string  `json:"name"`
-	Description           string  `json:"description"`
-	EstimatedDeliveryDays int     `json:"estimated_delivery_days"`
-	Cost                  float64 `json:"cost"`
-	FreeShipping          bool    `json:"free_shipping"`
+	ShippingRateID        uint   `json:"shipping_rate_id"`
+	ShippingMethodID      uint   `json:"shipping_method_id"`
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	EstimatedDeliveryDays int    `json:"estimated_delivery_days"`
+	Cost                  int64  `json:"cost"`
+	FreeShipping          bool   `json:"free_shipping"`
 }
 
 // NewShippingRate creates a new shipping rate
 func NewShippingRate(
-	shippingMethodID uint,
+	shippingMethodID,
 	shippingZoneID uint,
-	baseRate float64,
-	minOrderValue float64,
+	baseRate,
+	minOrderValue int64,
 ) (*ShippingRate, error) {
 	if shippingMethodID == 0 {
 		return nil, errors.New("shipping method ID cannot be empty")
@@ -91,7 +91,7 @@ func NewShippingRate(
 }
 
 // Update updates a shipping rate's details
-func (r *ShippingRate) Update(baseRate float64, minOrderValue float64) error {
+func (r *ShippingRate) Update(baseRate, minOrderValue int64) error {
 	if baseRate < 0 {
 		return errors.New("base rate cannot be negative")
 	}
@@ -107,7 +107,7 @@ func (r *ShippingRate) Update(baseRate float64, minOrderValue float64) error {
 }
 
 // SetFreeShippingThreshold sets the free shipping threshold
-func (r *ShippingRate) SetFreeShippingThreshold(threshold *float64) {
+func (r *ShippingRate) SetFreeShippingThreshold(threshold *int64) {
 	// Validate that threshold is either nil or positive
 	if threshold != nil && *threshold < 0 {
 		return
@@ -118,7 +118,7 @@ func (r *ShippingRate) SetFreeShippingThreshold(threshold *float64) {
 }
 
 // CalculateShippingCost calculates the shipping cost for an order
-func (r *ShippingRate) CalculateShippingCost(orderValue float64, weight float64) float64 {
+func (r *ShippingRate) CalculateShippingCost(orderValue int64, weight float64) int64 {
 	// Check if order qualifies for free shipping
 	if r.FreeShippingThreshold != nil && orderValue >= *r.FreeShippingThreshold {
 		return 0

--- a/internal/domain/money/money.go
+++ b/internal/domain/money/money.go
@@ -55,3 +55,8 @@ func FormatDollars(dollars float64, symbol string) string {
 func formatDollars(dollars float64) string {
 	return fmt.Sprintf("%.2f", dollars)
 }
+
+// ApplyPercentage applies a percentage to a cents value
+func ApplyPercentage(cents int64, percentage float64) int64 {
+	return ToCents(FromCents(cents) * percentage / 100)
+}

--- a/internal/domain/money/money.go
+++ b/internal/domain/money/money.go
@@ -1,0 +1,57 @@
+// Package money provides utilities for handling monetary values.
+// Money is stored as integers (cents) in the database to avoid floating-point precision issues.
+package money
+
+import (
+	"fmt"
+	"math"
+)
+
+// ToCents converts a dollar amount (float64) to cents (int64)
+// This avoids floating-point precision issues when storing money values
+func ToCents(dollars float64) int64 {
+	// Round to nearest cent to avoid floating point issues
+	// Multiply by 100 to convert dollars to cents
+	return int64(math.Round(dollars * 100))
+}
+
+// FromCents converts a cent amount (int64) to dollars (float64)
+func FromCents(cents int64) float64 {
+	// Divide by 100 to convert cents to dollars
+	return float64(cents) / 100
+}
+
+// ConvertNullableToCents converts a nullable dollar amount (*float64) to nullable cents (*int64)
+func ConvertNullableToCents(dollars *float64) *int64 {
+	if dollars == nil {
+		return nil
+	}
+	cents := ToCents(*dollars)
+	return &cents
+}
+
+// ConvertNullableFromCents converts a nullable cent amount (*int64) to nullable dollars (*float64)
+func ConvertNullableFromCents(cents *int64) *float64 {
+	if cents == nil {
+		return nil
+	}
+	dollars := FromCents(*cents)
+	return &dollars
+}
+
+// FormatCurrency formats a cents value (int64) as a currency string
+func FormatCurrency(cents int64, symbol string) string {
+	// Convert to dollars
+	dollars := FromCents(cents)
+	return symbol + formatDollars(dollars)
+}
+
+// FormatDollars formats a dollars value as a currency string
+func FormatDollars(dollars float64, symbol string) string {
+	return symbol + formatDollars(dollars)
+}
+
+// formatDollars is a helper function to format dollar values with 2 decimal places
+func formatDollars(dollars float64) string {
+	return fmt.Sprintf("%.2f", dollars)
+}

--- a/internal/domain/repository/payment_transaction_repository.go
+++ b/internal/domain/repository/payment_transaction_repository.go
@@ -31,5 +31,5 @@ type PaymentTransactionRepository interface {
 	CountSuccessfulByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (int, error)
 
 	// SumAmountByOrderIDAndType sums the amount of transactions of a specific type for an order
-	SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (float64, error)
+	SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (int64, error)
 }

--- a/internal/domain/repository/product_repository.go
+++ b/internal/domain/repository/product_repository.go
@@ -10,7 +10,8 @@ type ProductRepository interface {
 	Update(product *entity.Product) error
 	Delete(id uint) error
 	List(offset, limit int) ([]*entity.Product, error)
-	Search(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error)
+	// Search expects minPriceCents and maxPriceCents as int64 (cents)
+	Search(query string, categoryID uint, minPriceCents, maxPriceCents int64, offset, limit int) ([]*entity.Product, error)
 	GetBySeller(sellerID uint, offset, limit int) ([]*entity.Product, error)
 }
 

--- a/internal/domain/repository/shipping_repository.go
+++ b/internal/domain/repository/shipping_repository.go
@@ -26,7 +26,7 @@ type ShippingRateRepository interface {
 	GetByID(id uint) (*entity.ShippingRate, error)
 	GetByMethodID(methodID uint) ([]*entity.ShippingRate, error)
 	GetByZoneID(zoneID uint) ([]*entity.ShippingRate, error)
-	GetAvailableRatesForAddress(address entity.Address, orderValue float64) ([]*entity.ShippingRate, error)
+	GetAvailableRatesForAddress(address entity.Address, orderValue int64) ([]*entity.ShippingRate, error)
 	CreateWeightBasedRate(weightRate *entity.WeightBasedRate) error
 	CreateValueBasedRate(valueRate *entity.ValueBasedRate) error
 	GetWeightBasedRates(rateID uint) ([]entity.WeightBasedRate, error)

--- a/internal/domain/service/payment_service.go
+++ b/internal/domain/service/payment_service.go
@@ -33,7 +33,7 @@ type PaymentProvider struct {
 // PaymentRequest represents a request to process a payment
 type PaymentRequest struct {
 	OrderID         uint
-	Amount          float64
+	Amount          int64
 	Currency        string
 	PaymentMethod   PaymentMethod
 	PaymentProvider PaymentProviderType
@@ -89,10 +89,10 @@ type PaymentService interface {
 	VerifyPayment(transactionID string, provider PaymentProviderType) (bool, error)
 
 	// RefundPayment refunds a payment
-	RefundPayment(transactionID string, amount float64, provider PaymentProviderType) error
+	RefundPayment(transactionID string, amount int64, provider PaymentProviderType) error
 
 	// CapturePayment captures a payment
-	CapturePayment(transactionID string, amount float64, provider PaymentProviderType) error
+	CapturePayment(transactionID string, amount int64, provider PaymentProviderType) error
 
 	// CancelPayment cancels a payment
 	CancelPayment(transactionID string, provider PaymentProviderType) error

--- a/internal/infrastructure/payment/mobilepay_payment_service.go
+++ b/internal/infrastructure/payment/mobilepay_payment_service.go
@@ -91,14 +91,11 @@ func (s *MobilePayPaymentService) ProcessPayment(request service.PaymentRequest)
 	// Generate a unique reference for this payment
 	reference := fmt.Sprintf("order-%d-%s", request.OrderID, uuid.New().String())
 
-	// Convert amount to smallest currency unit (øre/cents)
-	amountInSmallestUnit := int64(request.Amount * 100)
-
 	// Construct the payment request
 	paymentRequest := models.CreatePaymentRequest{
 		Amount: models.Amount{
 			Currency: "DKK",
-			Value:    int(amountInSmallestUnit),
+			Value:    int(request.Amount),
 		},
 		Customer: &models.Customer{
 			PhoneNumber: &phoneNumber,
@@ -153,19 +150,16 @@ func (s *MobilePayPaymentService) VerifyPayment(transactionID string, provider s
 }
 
 // RefundPayment refunds a payment
-func (s *MobilePayPaymentService) RefundPayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MobilePayPaymentService) RefundPayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if provider != service.PaymentProviderMobilePay {
 		return errors.New("invalid payment provider")
 	}
-  
-	// Convert amount to smallest currency unit (øre/cents)
-	amountInSmallestUnit := int64(amount * 100)
 
 	// Prepare refund request
 	refundRequest := models.ModificationRequest{
 		ModificationAmount: models.Amount{
 			Currency: "DKK",
-			Value:    int(amountInSmallestUnit),
+			Value:    int(amount),
 		},
 	}
 
@@ -179,7 +173,7 @@ func (s *MobilePayPaymentService) RefundPayment(transactionID string, amount flo
 }
 
 // CapturePayment captures an authorized payment
-func (s *MobilePayPaymentService) CapturePayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MobilePayPaymentService) CapturePayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if provider != service.PaymentProviderMobilePay {
 		return errors.New("invalid payment provider")
 	}
@@ -188,14 +182,11 @@ func (s *MobilePayPaymentService) CapturePayment(transactionID string, amount fl
 		return errors.New("transaction ID is required")
 	}
 
-	// Convert amount to smallest currency unit (øre/cents)
-	amountInSmallestUnit := int64(amount * 100)
-
 	// Prepare capture request
 	captureRequest := models.ModificationRequest{
 		ModificationAmount: models.Amount{
 			Currency: "DKK",
-			Value:    int(amountInSmallestUnit),
+			Value:    int(amount),
 		},
 	}
 

--- a/internal/infrastructure/payment/mock_payment_service.go
+++ b/internal/infrastructure/payment/mock_payment_service.go
@@ -117,7 +117,7 @@ func (s *MockPaymentService) VerifyPayment(transactionID string, provider servic
 }
 
 // RefundPayment refunds a payment
-func (s *MockPaymentService) RefundPayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MockPaymentService) RefundPayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if transactionID == "" {
 		return errors.New("transaction ID is required")
 	}
@@ -133,7 +133,7 @@ func (s *MockPaymentService) RefundPayment(transactionID string, amount float64,
 }
 
 // CapturePayment captures a payment
-func (s *MockPaymentService) CapturePayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MockPaymentService) CapturePayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if transactionID == "" {
 		return errors.New("transaction ID is required")
 	}

--- a/internal/infrastructure/payment/multi_provider_payment_service.go
+++ b/internal/infrastructure/payment/multi_provider_payment_service.go
@@ -152,7 +152,7 @@ func (s *MultiProviderPaymentService) VerifyPayment(transactionID string, provid
 }
 
 // RefundPayment refunds a payment
-func (s *MultiProviderPaymentService) RefundPayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MultiProviderPaymentService) RefundPayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	paymentProvider, exists := s.providers[provider]
 	if !exists {
 		return fmt.Errorf("payment provider %s not available", provider)
@@ -162,7 +162,7 @@ func (s *MultiProviderPaymentService) RefundPayment(transactionID string, amount
 }
 
 // CapturePayment captures a payment
-func (s *MultiProviderPaymentService) CapturePayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *MultiProviderPaymentService) CapturePayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	paymentProvider, exists := s.providers[provider]
 	if !exists {
 		return fmt.Errorf("payment provider %s not available", provider)

--- a/internal/infrastructure/payment/stripe_payment_service.go
+++ b/internal/infrastructure/payment/stripe_payment_service.go
@@ -176,7 +176,7 @@ func (s *StripePaymentService) VerifyPayment(transactionID string, provider serv
 }
 
 // RefundPayment refunds a payment
-func (s *StripePaymentService) RefundPayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *StripePaymentService) RefundPayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if transactionID == "" {
 		return errors.New("transaction ID is required")
 	}
@@ -204,7 +204,7 @@ func (s *StripePaymentService) RefundPayment(transactionID string, amount float6
 }
 
 // CapturePayment captures a payment
-func (s *StripePaymentService) CapturePayment(transactionID string, amount float64, provider service.PaymentProviderType) error {
+func (s *StripePaymentService) CapturePayment(transactionID string, amount int64, provider service.PaymentProviderType) error {
 	if transactionID == "" {
 		return errors.New("transaction ID is required")
 	}

--- a/internal/infrastructure/repository/postgres/order_repository.go
+++ b/internal/infrastructure/repository/postgres/order_repository.go
@@ -328,12 +328,12 @@ func (r *OrderRepository) Update(order *entity.Order) error {
 
 	var discountID sql.NullInt64
 	var discountCode sql.NullString
-	discountAmount := 0.0
+	var discountAmount sql.NullInt64
 
 	if order.AppliedDiscount != nil && order.AppliedDiscount.DiscountID > 0 {
 		discountID.Int64 = int64(order.AppliedDiscount.DiscountID)
 		discountID.Valid = true
-		discountAmount = order.AppliedDiscount.DiscountAmount
+		discountAmount.Int64 = order.AppliedDiscount.DiscountAmount
 		discountCode.String = order.AppliedDiscount.DiscountCode
 		discountCode.Valid = true
 	}

--- a/internal/infrastructure/repository/postgres/payment_transaction_repository.go
+++ b/internal/infrastructure/repository/postgres/payment_transaction_repository.go
@@ -352,14 +352,14 @@ func (r *paymentTransactionRepository) CountSuccessfulByOrderIDAndType(orderID u
 }
 
 // SumAmountByOrderIDAndType sums the amount of transactions of a specific type for an order
-func (r *paymentTransactionRepository) SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (float64, error) {
+func (r *paymentTransactionRepository) SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (int64, error) {
 	query := `
 		SELECT COALESCE(SUM(amount), 0)
 		FROM payment_transactions
 		WHERE order_id = $1 AND type = $2 AND status = $3
 	`
 
-	var total float64
+	var total int64
 	err := r.db.QueryRow(query, orderID, string(transactionType), string(entity.TransactionStatusSuccessful)).Scan(&total)
 	if err != nil {
 		return 0, fmt.Errorf("failed to sum transaction amounts: %w", err)

--- a/internal/infrastructure/repository/postgres/product_repository.go
+++ b/internal/infrastructure/repository/postgres/product_repository.go
@@ -291,8 +291,8 @@ func (r *ProductRepository) List(offset, limit int) ([]*entity.Product, error) {
 	return products, nil
 }
 
-// Search searches for products based on criteria
-func (r *ProductRepository) Search(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error) {
+// Search searches for products based on criteria (prices in cents)
+func (r *ProductRepository) Search(query string, categoryID uint, minPriceCents, maxPriceCents int64, offset, limit int) ([]*entity.Product, error) {
 	// Build dynamic query parts
 	searchQuery := `
 		SELECT id, product_number, name, description, price, stock, weight, category_id, seller_id, images, has_variants, created_at, updated_at
@@ -314,15 +314,15 @@ func (r *ProductRepository) Search(query string, categoryID uint, minPrice, maxP
 		paramCounter++
 	}
 
-	if minPrice > 0 {
+	if minPriceCents > 0 {
 		searchQuery += fmt.Sprintf(" AND price >= $%d", paramCounter)
-		queryParams = append(queryParams, minPrice)
+		queryParams = append(queryParams, minPriceCents) // Use cents
 		paramCounter++
 	}
 
-	if maxPrice > 0 {
+	if maxPriceCents > 0 {
 		searchQuery += fmt.Sprintf(" AND price <= $%d", paramCounter)
-		queryParams = append(queryParams, maxPrice)
+		queryParams = append(queryParams, maxPriceCents) // Use cents
 		paramCounter++
 	}
 
@@ -349,7 +349,7 @@ func (r *ProductRepository) Search(query string, categoryID uint, minPrice, maxP
 			&productNumber,
 			&product.Name,
 			&product.Description,
-			&product.Price,
+			&product.Price, // Reads int64 directly
 			&product.Stock,
 			&product.Weight,
 			&product.CategoryID,

--- a/internal/infrastructure/repository/postgres/shipping_rate_repository.go
+++ b/internal/infrastructure/repository/postgres/shipping_rate_repository.go
@@ -31,9 +31,9 @@ func (r *ShippingRateRepository) Create(rate *entity.ShippingRate) error {
 		RETURNING id
 	`
 
-	var freeShippingThresholdSQL sql.NullFloat64
+	var freeShippingThresholdSQL sql.NullInt64
 	if rate.FreeShippingThreshold != nil {
-		freeShippingThresholdSQL.Float64 = *rate.FreeShippingThreshold
+		freeShippingThresholdSQL.Int64 = *rate.FreeShippingThreshold
 		freeShippingThresholdSQL.Valid = true
 	}
 
@@ -62,7 +62,7 @@ func (r *ShippingRateRepository) GetByID(id uint) (*entity.ShippingRate, error) 
 		WHERE id = $1
 	`
 
-	var freeShippingThresholdSQL sql.NullFloat64
+	var freeShippingThresholdSQL sql.NullInt64
 	rate := &entity.ShippingRate{
 		ShippingMethod: &entity.ShippingMethod{},
 		ShippingZone:   &entity.ShippingZone{},
@@ -90,7 +90,7 @@ func (r *ShippingRateRepository) GetByID(id uint) (*entity.ShippingRate, error) 
 
 	// Set free shipping threshold if available
 	if freeShippingThresholdSQL.Valid {
-		value := freeShippingThresholdSQL.Float64
+		value := freeShippingThresholdSQL.Int64
 		rate.FreeShippingThreshold = &value
 	}
 
@@ -196,7 +196,7 @@ func (r *ShippingRateRepository) GetByMethodID(methodID uint) ([]*entity.Shippin
 
 	rates := []*entity.ShippingRate{}
 	for rows.Next() {
-		var freeShippingThresholdSQL sql.NullFloat64
+		var freeShippingThresholdSQL sql.NullInt64
 		rate := &entity.ShippingRate{}
 		err := rows.Scan(
 			&rate.ID,
@@ -215,7 +215,7 @@ func (r *ShippingRateRepository) GetByMethodID(methodID uint) ([]*entity.Shippin
 
 		// Set free shipping threshold if available
 		if freeShippingThresholdSQL.Valid {
-			value := freeShippingThresholdSQL.Float64
+			value := freeShippingThresholdSQL.Int64
 			rate.FreeShippingThreshold = &value
 		}
 
@@ -243,7 +243,7 @@ func (r *ShippingRateRepository) GetByZoneID(zoneID uint) ([]*entity.ShippingRat
 
 	rates := []*entity.ShippingRate{}
 	for rows.Next() {
-		var freeShippingThresholdSQL sql.NullFloat64
+		var freeShippingThresholdSQL sql.NullInt64
 		rate := &entity.ShippingRate{}
 		err := rows.Scan(
 			&rate.ID,
@@ -262,7 +262,7 @@ func (r *ShippingRateRepository) GetByZoneID(zoneID uint) ([]*entity.ShippingRat
 
 		// Set free shipping threshold if available
 		if freeShippingThresholdSQL.Valid {
-			value := freeShippingThresholdSQL.Float64
+			value := freeShippingThresholdSQL.Int64
 			rate.FreeShippingThreshold = &value
 		}
 
@@ -273,7 +273,7 @@ func (r *ShippingRateRepository) GetByZoneID(zoneID uint) ([]*entity.ShippingRat
 }
 
 // GetAvailableRatesForAddress retrieves available shipping rates for a specific address
-func (r *ShippingRateRepository) GetAvailableRatesForAddress(address entity.Address, orderValue float64) ([]*entity.ShippingRate, error) {
+func (r *ShippingRateRepository) GetAvailableRatesForAddress(address entity.Address, orderValue int64) ([]*entity.ShippingRate, error) {
 	// First, find applicable shipping zones for this address
 	query := `
 		SELECT id 
@@ -349,7 +349,7 @@ func (r *ShippingRateRepository) GetAvailableRatesForAddress(address entity.Addr
 
 	rates := []*entity.ShippingRate{}
 	for rateRows.Next() {
-		var freeShippingThresholdSQL sql.NullFloat64
+		var freeShippingThresholdSQL sql.NullInt64
 		rate := &entity.ShippingRate{
 			ShippingMethod: &entity.ShippingMethod{},
 		}
@@ -377,7 +377,7 @@ func (r *ShippingRateRepository) GetAvailableRatesForAddress(address entity.Addr
 
 		// Set free shipping threshold if available
 		if freeShippingThresholdSQL.Valid {
-			value := freeShippingThresholdSQL.Float64
+			value := freeShippingThresholdSQL.Int64
 			rate.FreeShippingThreshold = &value
 		}
 
@@ -525,9 +525,9 @@ func (r *ShippingRateRepository) Update(rate *entity.ShippingRate) error {
 		WHERE id = $8
 	`
 
-	var freeShippingThresholdSQL sql.NullFloat64
+	var freeShippingThresholdSQL sql.NullInt64
 	if rate.FreeShippingThreshold != nil {
-		freeShippingThresholdSQL.Float64 = *rate.FreeShippingThreshold
+		freeShippingThresholdSQL.Int64 = *rate.FreeShippingThreshold
 		freeShippingThresholdSQL.Valid = true
 	}
 

--- a/internal/interfaces/api/handler/payment_handler.go
+++ b/internal/interfaces/api/handler/payment_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/zenfulcode/commercify/internal/application/usecase"
+	"github.com/zenfulcode/commercify/internal/domain/money"
 	"github.com/zenfulcode/commercify/internal/infrastructure/logger"
 )
 
@@ -60,7 +61,7 @@ func (h *PaymentHandler) CapturePayment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Capture payment
-	err := h.orderUseCase.CapturePayment(paymentID, input.Amount)
+	err := h.orderUseCase.CapturePayment(paymentID, money.ToCents(input.Amount))
 	if err != nil {
 		h.logger.Error("Failed to capture payment: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -127,7 +128,7 @@ func (h *PaymentHandler) RefundPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Refund payment
-	err := h.orderUseCase.RefundPayment(paymentID, input.Amount)
+	err := h.orderUseCase.RefundPayment(paymentID, money.ToCents(input.Amount))
 	if err != nil {
 		h.logger.Error("Failed to refund payment: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/interfaces/api/handler/shipping_handler.go
+++ b/internal/interfaces/api/handler/shipping_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/zenfulcode/commercify/internal/application/usecase"
 	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/internal/domain/money"
 	"github.com/zenfulcode/commercify/internal/infrastructure/logger"
 )
 
@@ -42,7 +43,7 @@ func (h *ShippingHandler) CalculateShippingOptions(w http.ResponseWriter, r *htt
 	// Calculate shipping options
 	options, err := h.shippingUseCase.CalculateShippingOptions(
 		requestBody.Address,
-		requestBody.OrderValue,
+		money.ToCents(requestBody.OrderValue),
 		requestBody.OrderWeight,
 	)
 	if err != nil {
@@ -399,7 +400,7 @@ func (h *ShippingHandler) GetShippingCost(w http.ResponseWriter, r *http.Request
 	// Calculate shipping cost
 	cost, err := h.shippingUseCase.GetShippingCost(
 		uint(id),
-		requestBody.OrderValue,
+		money.ToCents(requestBody.OrderValue),
 		requestBody.OrderWeight,
 	)
 	if err != nil {
@@ -410,7 +411,7 @@ func (h *ShippingHandler) GetShippingCost(w http.ResponseWriter, r *http.Request
 
 	// Return shipping cost
 	response := map[string]float64{
-		"cost": cost,
+		"cost": money.FromCents(cost),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)

--- a/migrations/000011_store_money_as_int64.down.sql
+++ b/migrations/000011_store_money_as_int64.down.sql
@@ -1,0 +1,178 @@
+-- Migration to revert money fields from INT (cents) back to DECIMAL
+-- Create temporary columns with _decimal suffix
+
+-- Products table
+ALTER TABLE products ADD COLUMN price_decimal DECIMAL(10, 2);
+ALTER TABLE products ADD COLUMN compare_price_decimal DECIMAL(10, 2);
+UPDATE products SET price_decimal = price::DECIMAL / 100, compare_price_decimal = compare_price::DECIMAL / 100;
+
+-- Product variants table
+ALTER TABLE product_variants ADD COLUMN price_decimal DECIMAL(10, 2);
+ALTER TABLE product_variants ADD COLUMN compare_price_decimal DECIMAL(10, 2);
+UPDATE product_variants SET price_decimal = price::DECIMAL / 100, compare_price_decimal = compare_price::DECIMAL / 100;
+
+-- Orders table
+ALTER TABLE orders ADD COLUMN total_amount_decimal DECIMAL(10, 2);
+ALTER TABLE orders ADD COLUMN shipping_cost_decimal DECIMAL(10, 2);
+ALTER TABLE orders ADD COLUMN discount_amount_decimal DECIMAL(10, 2);
+ALTER TABLE orders ADD COLUMN final_amount_decimal DECIMAL(10, 2);
+UPDATE orders SET 
+    total_amount_decimal = total_amount::DECIMAL / 100,
+    shipping_cost_decimal = shipping_cost::DECIMAL / 100,
+    discount_amount_decimal = discount_amount::DECIMAL / 100,
+    final_amount_decimal = final_amount::DECIMAL / 100;
+
+-- Order items table
+ALTER TABLE order_items ADD COLUMN price_decimal DECIMAL(10, 2);
+ALTER TABLE order_items ADD COLUMN subtotal_decimal DECIMAL(10, 2);
+UPDATE order_items SET 
+    price_decimal = price::DECIMAL / 100,
+    subtotal_decimal = subtotal::DECIMAL / 100;
+
+-- Shipping rates table
+ALTER TABLE shipping_rates ADD COLUMN base_rate_decimal DECIMAL(10, 2);
+ALTER TABLE shipping_rates ADD COLUMN min_order_value_decimal DECIMAL(10, 2);
+ALTER TABLE shipping_rates ADD COLUMN free_shipping_threshold_decimal DECIMAL(10, 2);
+UPDATE shipping_rates SET 
+    base_rate_decimal = base_rate::DECIMAL / 100,
+    min_order_value_decimal = min_order_value::DECIMAL / 100,
+    free_shipping_threshold_decimal = CASE WHEN free_shipping_threshold IS NOT NULL THEN free_shipping_threshold::DECIMAL / 100 ELSE NULL END;
+
+-- Weight-based rates table
+ALTER TABLE weight_based_rates ADD COLUMN rate_decimal DECIMAL(10, 2);
+UPDATE weight_based_rates SET rate_decimal = rate::DECIMAL / 100;
+
+-- Value-based rates table
+ALTER TABLE value_based_rates ADD COLUMN min_order_value_decimal DECIMAL(10, 2);
+ALTER TABLE value_based_rates ADD COLUMN max_order_value_decimal DECIMAL(10, 2);
+ALTER TABLE value_based_rates ADD COLUMN rate_decimal DECIMAL(10, 2);
+UPDATE value_based_rates SET 
+    min_order_value_decimal = min_order_value::DECIMAL / 100,
+    max_order_value_decimal = max_order_value::DECIMAL / 100,
+    rate_decimal = rate::DECIMAL / 100;
+
+-- Discounts table
+ALTER TABLE discounts ADD COLUMN value_decimal DECIMAL(10, 2);
+ALTER TABLE discounts ADD COLUMN min_order_value_decimal DECIMAL(10, 2);
+ALTER TABLE discounts ADD COLUMN max_discount_value_decimal DECIMAL(10, 2);
+UPDATE discounts SET 
+    value_decimal = value::DECIMAL / 100,
+    min_order_value_decimal = min_order_value::DECIMAL / 100,
+    max_discount_value_decimal = max_discount_value::DECIMAL / 100;
+
+-- Payment transactions table
+ALTER TABLE payment_transactions ADD COLUMN amount_decimal DECIMAL(10, 2);
+UPDATE payment_transactions SET amount_decimal = amount::DECIMAL / 100;
+
+-- Now drop the int columns and rename the decimal ones
+-- Products
+ALTER TABLE products DROP COLUMN price;
+ALTER TABLE products DROP COLUMN compare_price;
+ALTER TABLE products RENAME COLUMN price_decimal TO price;
+ALTER TABLE products RENAME COLUMN compare_price_decimal TO compare_price;
+
+-- Product variants
+ALTER TABLE product_variants DROP COLUMN price;
+ALTER TABLE product_variants DROP COLUMN compare_price;
+ALTER TABLE product_variants RENAME COLUMN price_decimal TO price;
+ALTER TABLE product_variants RENAME COLUMN compare_price_decimal TO compare_price;
+
+-- Orders
+ALTER TABLE orders DROP COLUMN total_amount;
+ALTER TABLE orders DROP COLUMN shipping_cost;
+ALTER TABLE orders DROP COLUMN discount_amount;
+ALTER TABLE orders DROP COLUMN final_amount;
+ALTER TABLE orders RENAME COLUMN total_amount_decimal TO total_amount;
+ALTER TABLE orders RENAME COLUMN shipping_cost_decimal TO shipping_cost;
+ALTER TABLE orders RENAME COLUMN discount_amount_decimal TO discount_amount;
+ALTER TABLE orders RENAME COLUMN final_amount_decimal TO final_amount;
+
+-- Order items
+ALTER TABLE order_items DROP COLUMN price;
+ALTER TABLE order_items DROP COLUMN subtotal;
+ALTER TABLE order_items RENAME COLUMN price_decimal TO price;
+ALTER TABLE order_items RENAME COLUMN subtotal_decimal TO subtotal;
+
+-- Shipping rates
+ALTER TABLE shipping_rates DROP COLUMN base_rate;
+ALTER TABLE shipping_rates DROP COLUMN min_order_value;
+ALTER TABLE shipping_rates DROP COLUMN free_shipping_threshold;
+ALTER TABLE shipping_rates RENAME COLUMN base_rate_decimal TO base_rate;
+ALTER TABLE shipping_rates RENAME COLUMN min_order_value_decimal TO min_order_value;
+ALTER TABLE shipping_rates RENAME COLUMN free_shipping_threshold_decimal TO free_shipping_threshold;
+
+-- Weight-based rates
+ALTER TABLE weight_based_rates DROP COLUMN rate;
+ALTER TABLE weight_based_rates RENAME COLUMN rate_decimal TO rate;
+
+-- Value-based rates
+ALTER TABLE value_based_rates DROP COLUMN min_order_value;
+ALTER TABLE value_based_rates DROP COLUMN max_order_value;
+ALTER TABLE value_based_rates DROP COLUMN rate;
+ALTER TABLE value_based_rates RENAME COLUMN min_order_value_decimal TO min_order_value;
+ALTER TABLE value_based_rates RENAME COLUMN max_order_value_decimal TO max_order_value;
+ALTER TABLE value_based_rates RENAME COLUMN rate_decimal TO rate;
+
+-- Discounts
+ALTER TABLE discounts DROP COLUMN value;
+ALTER TABLE discounts DROP COLUMN min_order_value;
+ALTER TABLE discounts DROP COLUMN max_discount_value;
+ALTER TABLE discounts RENAME COLUMN value_decimal TO value;
+ALTER TABLE discounts RENAME COLUMN min_order_value_decimal TO min_order_value;
+ALTER TABLE discounts RENAME COLUMN max_discount_value_decimal TO max_discount_value;
+
+-- Payment transactions
+ALTER TABLE payment_transactions DROP COLUMN amount;
+ALTER TABLE payment_transactions RENAME COLUMN amount_decimal TO amount;
+
+-- Revert migration changing money fields from BIGINT (cents) back to DECIMAL (dollars)
+
+-- Order table
+ALTER TABLE orders
+    ALTER COLUMN shipping_cost TYPE DECIMAL(10, 2) USING (shipping_cost / 100.0),
+    ALTER COLUMN total_amount TYPE DECIMAL(10, 2) USING (total_amount / 100.0),
+    ALTER COLUMN final_amount TYPE DECIMAL(10, 2) USING (final_amount / 100.0),
+    ALTER COLUMN discount_amount TYPE DECIMAL(10, 2) USING (discount_amount / 100.0);
+
+-- OrderItem table
+ALTER TABLE order_items
+    ALTER COLUMN price TYPE DECIMAL(10, 2) USING (price / 100.0),
+    ALTER COLUMN subtotal TYPE DECIMAL(10, 2) USING (subtotal / 100.0);
+
+-- PaymentTransaction table
+ALTER TABLE payment_transactions
+    ALTER COLUMN amount TYPE DECIMAL(10, 2) USING (amount / 100.0);
+
+-- Discounts table
+ALTER TABLE discounts
+    ALTER COLUMN value TYPE DECIMAL(10, 2) USING (value / 100.0),
+    ALTER COLUMN min_order_value TYPE DECIMAL(10, 2) USING (min_order_value / 100.0),
+    ALTER COLUMN max_discount_value TYPE DECIMAL(10, 2) USING (max_discount_value / 100.0);
+
+-- ShippingRate table
+ALTER TABLE shipping_rates
+    ALTER COLUMN base_rate TYPE DECIMAL(10, 2) USING (base_rate / 100.0),
+    ALTER COLUMN min_order_value TYPE DECIMAL(10, 2) USING (min_order_value / 100.0),
+    ALTER COLUMN free_shipping_threshold TYPE DECIMAL(10, 2) USING (free_shipping_threshold / 100.0);
+
+-- WeightBasedRate table
+ALTER TABLE weight_based_rates
+    ALTER COLUMN rate TYPE DECIMAL(10, 2) USING (rate / 100.0);
+
+-- ValueBasedRate table
+ALTER TABLE value_based_rates
+    ALTER COLUMN rate TYPE DECIMAL(10, 2) USING (rate / 100.0),
+    ALTER COLUMN min_order_value TYPE DECIMAL(10, 2) USING (min_order_value / 100.0),
+    ALTER COLUMN max_order_value TYPE DECIMAL(10, 2) USING (max_order_value / 100.0);
+
+-- Products table
+ALTER TABLE products
+    ALTER COLUMN price TYPE DECIMAL(10, 2) USING (price / 100.0),
+    ALTER COLUMN compare_price TYPE DECIMAL(10, 2) USING (compare_price / 100.0),
+    ALTER COLUMN cost_price TYPE DECIMAL(10, 2) USING (cost_price / 100.0);
+
+-- ProductVariants table
+ALTER TABLE product_variants
+    ALTER COLUMN price TYPE DECIMAL(10, 2) USING (price / 100.0),
+    ALTER COLUMN compare_price TYPE DECIMAL(10, 2) USING (compare_price / 100.0),
+    ALTER COLUMN cost_price TYPE DECIMAL(10, 2) USING (cost_price / 100.0);

--- a/migrations/000011_store_money_as_int64.down.sql
+++ b/migrations/000011_store_money_as_int64.down.sql
@@ -53,7 +53,6 @@ UPDATE value_based_rates SET
     rate_decimal = rate::DECIMAL / 100;
 
 -- Discounts table
-ALTER TABLE discounts ADD COLUMN value_decimal DECIMAL(10, 2);
 ALTER TABLE discounts ADD COLUMN min_order_value_decimal DECIMAL(10, 2);
 ALTER TABLE discounts ADD COLUMN max_discount_value_decimal DECIMAL(10, 2);
 UPDATE discounts SET 

--- a/migrations/000011_store_money_as_int64.up.sql
+++ b/migrations/000011_store_money_as_int64.up.sql
@@ -1,0 +1,52 @@
+-- Migration to change money fields from DECIMAL to BIGINT (int64)
+-- This stores monetary values as cents instead of dollars to avoid floating point issues
+
+-- Order table
+ALTER TABLE orders
+    ALTER COLUMN shipping_cost TYPE BIGINT USING (shipping_cost * 100)::BIGINT,
+    ALTER COLUMN total_amount TYPE BIGINT USING (total_amount * 100)::BIGINT,
+    ALTER COLUMN final_amount TYPE BIGINT USING (final_amount * 100)::BIGINT,
+    ALTER COLUMN discount_amount TYPE BIGINT USING (discount_amount * 100)::BIGINT;
+
+-- OrderItem table
+ALTER TABLE order_items
+    ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT,
+    ALTER COLUMN subtotal TYPE BIGINT USING (subtotal * 100)::BIGINT;
+
+-- PaymentTransaction table
+ALTER TABLE payment_transactions
+    ALTER COLUMN amount TYPE BIGINT USING (amount * 100)::BIGINT;
+
+-- Discounts table
+ALTER TABLE discounts
+    ALTER COLUMN value TYPE BIGINT USING (value * 100)::BIGINT,
+    ALTER COLUMN min_order_value TYPE BIGINT USING (min_order_value * 100)::BIGINT,
+    ALTER COLUMN max_discount_value TYPE BIGINT USING (max_discount_value * 100)::BIGINT;
+
+-- ShippingRate table
+ALTER TABLE shipping_rates
+    ALTER COLUMN base_rate TYPE BIGINT USING (base_rate * 100)::BIGINT,
+    ALTER COLUMN min_order_value TYPE BIGINT USING (min_order_value * 100)::BIGINT,
+    ALTER COLUMN free_shipping_threshold TYPE BIGINT USING (free_shipping_threshold * 100)::BIGINT;
+
+-- WeightBasedRate table
+ALTER TABLE weight_based_rates
+    ALTER COLUMN rate TYPE BIGINT USING (rate * 100)::BIGINT;
+
+-- ValueBasedRate table
+ALTER TABLE value_based_rates
+    ALTER COLUMN rate TYPE BIGINT USING (rate * 100)::BIGINT,
+    ALTER COLUMN min_order_value TYPE BIGINT USING (min_order_value * 100)::BIGINT,
+    ALTER COLUMN max_order_value TYPE BIGINT USING (max_order_value * 100)::BIGINT;
+
+-- Products table
+ALTER TABLE products
+    ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT,
+    ALTER COLUMN compare_price TYPE BIGINT USING (compare_price * 100)::BIGINT,
+    ALTER COLUMN cost_price TYPE BIGINT USING (cost_price * 100)::BIGINT;
+
+-- ProductVariants table
+ALTER TABLE product_variants
+    ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT,
+    ALTER COLUMN compare_price TYPE BIGINT USING (compare_price * 100)::BIGINT,
+    ALTER COLUMN cost_price TYPE BIGINT USING (cost_price * 100)::BIGINT;

--- a/migrations/000011_store_money_as_int64.up.sql
+++ b/migrations/000011_store_money_as_int64.up.sql
@@ -19,7 +19,6 @@ ALTER TABLE payment_transactions
 
 -- Discounts table
 ALTER TABLE discounts
-    ALTER COLUMN value TYPE BIGINT USING (value * 100)::BIGINT,
     ALTER COLUMN min_order_value TYPE BIGINT USING (min_order_value * 100)::BIGINT,
     ALTER COLUMN max_discount_value TYPE BIGINT USING (max_discount_value * 100)::BIGINT;
 
@@ -41,12 +40,14 @@ ALTER TABLE value_based_rates
 
 -- Products table
 ALTER TABLE products
-    ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT,
-    ALTER COLUMN compare_price TYPE BIGINT USING (compare_price * 100)::BIGINT,
-    ALTER COLUMN cost_price TYPE BIGINT USING (cost_price * 100)::BIGINT;
+    ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT;
 
 -- ProductVariants table
 ALTER TABLE product_variants
     ALTER COLUMN price TYPE BIGINT USING (price * 100)::BIGINT,
-    ALTER COLUMN compare_price TYPE BIGINT USING (compare_price * 100)::BIGINT,
-    ALTER COLUMN cost_price TYPE BIGINT USING (cost_price * 100)::BIGINT;
+    ALTER COLUMN compare_price TYPE BIGINT USING (compare_price * 100)::BIGINT;
+
+-- Add any missing columns (compare_price, cost_price) for future use
+ALTER TABLE products ADD COLUMN IF NOT EXISTS compare_price BIGINT DEFAULT 0;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS cost_price BIGINT DEFAULT 0;
+ALTER TABLE product_variants ADD COLUMN IF NOT EXISTS cost_price BIGINT DEFAULT 0;

--- a/testutil/mock/payment_transaction_repository.go
+++ b/testutil/mock/payment_transaction_repository.go
@@ -165,13 +165,13 @@ func (m *MockPaymentTransactionRepository) CountSuccessfulByOrderIDAndType(order
 }
 
 // SumAmountByOrderIDAndType sums the amount of transactions of a specific type for an order
-func (m *MockPaymentTransactionRepository) SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (float64, error) {
+func (m *MockPaymentTransactionRepository) SumAmountByOrderIDAndType(orderID uint, transactionType entity.TransactionType) (int64, error) {
 	transactions, ok := m.byOrderID[orderID]
 	if !ok {
 		return 0, nil
 	}
 
-	var total float64 = 0
+	var total int64
 	for _, tx := range transactions {
 		if tx.Type == transactionType && tx.Status == entity.TransactionStatusSuccessful {
 			total += tx.Amount

--- a/testutil/mock/product_repository.go
+++ b/testutil/mock/product_repository.go
@@ -13,7 +13,7 @@ type MockProductRepository struct {
 	bySeller map[uint][]*entity.Product
 	lastID   uint
 	// Add MockSearch function field for custom search behavior in tests
-	MockSearch func(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error)
+	MockSearch func(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error)
 }
 
 // NewMockProductRepository creates a new instance of MockProductRepository
@@ -105,7 +105,7 @@ func (r *MockProductRepository) List(offset, limit int) ([]*entity.Product, erro
 }
 
 // Search searches for products based on criteria
-func (r *MockProductRepository) Search(query string, categoryID uint, minPrice, maxPrice float64, offset, limit int) ([]*entity.Product, error) {
+func (r *MockProductRepository) Search(query string, categoryID uint, minPrice, maxPrice int64, offset, limit int) ([]*entity.Product, error) {
 	if r.MockSearch != nil {
 		// Use the custom search function if provided
 		return r.MockSearch(query, categoryID, minPrice, maxPrice, offset, limit)


### PR DESCRIPTION
This pull request introduces a refactor to standardize monetary values across the codebase by using a `money.ToCents` utility function. The changes ensure consistent handling of monetary amounts as integers (representing cents) instead of floating-point numbers. This update affects the seeding scripts, discount use cases, and associated tests.