### PR TITLE
feat: Enhance UpdateCategory to handle ParentID logic

### DIFF
--- a/internal/infrastructure/repository/gorm/category_repository.go
+++ b/internal/infrastructure/repository/gorm/category_repository.go
@@ -61,8 +61,8 @@ func (c *CategoryRepository) List() ([]*entity.Category, error) {
 
 // Update implements repository.CategoryRepository.
 func (c *CategoryRepository) Update(category *entity.Category) error {
-	// Use Select with "*" and Omit to ensure all fields are updated, including nil values
-	return c.db.Select("*").Omit("created_at").Save(category).Error
+	// Use explicit field updates to ensure parent_id is properly updated when nil
+	return c.db.Model(category).Select("name", "description", "parent_id").Updates(category).Error
 }
 
 // NewCategoryRepository creates a new GORM-based CategoryRepository

--- a/internal/infrastructure/repository/gorm/category_repository.go
+++ b/internal/infrastructure/repository/gorm/category_repository.go
@@ -23,7 +23,7 @@ func (c *CategoryRepository) Create(category *entity.Category) error {
 func (c *CategoryRepository) Delete(categoryID uint) error {
 	// Note: This will fail if there are products in this category due to RESTRICT constraint
 	// which is the intended behavior for data integrity
-	return c.db.Delete(&entity.Category{}, categoryID).Error
+	return c.db.Unscoped().Delete(&entity.Category{}, categoryID).Error
 }
 
 // GetByID implements repository.CategoryRepository.
@@ -61,7 +61,8 @@ func (c *CategoryRepository) List() ([]*entity.Category, error) {
 
 // Update implements repository.CategoryRepository.
 func (c *CategoryRepository) Update(category *entity.Category) error {
-	return c.db.Save(category).Error
+	// Use Select with "*" and Omit to ensure all fields are updated, including nil values
+	return c.db.Select("*").Omit("created_at").Save(category).Error
 }
 
 // NewCategoryRepository creates a new GORM-based CategoryRepository

--- a/internal/infrastructure/repository/gorm/category_repository_test.go
+++ b/internal/infrastructure/repository/gorm/category_repository_test.go
@@ -1,0 +1,150 @@
+package gorm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zenfulcode/commercify/internal/domain/entity"
+	"github.com/zenfulcode/commercify/testutil"
+)
+
+func TestCategoryRepository_UpdateParentID(t *testing.T) {
+	// Setup
+	db := testutil.SetupTestDB(t)
+	defer testutil.CleanupTestDB(t, db)
+
+	repo := NewCategoryRepository(db)
+
+	t.Run("should update ParentID from nil to valid ID", func(t *testing.T) {
+		// Create parent category
+		parentCategory, err := entity.NewCategory("Parent Category", "Parent description", nil)
+		require.NoError(t, err)
+		err = repo.Create(parentCategory)
+		require.NoError(t, err)
+
+		// Create child category without parent
+		childCategory, err := entity.NewCategory("Child Category", "Child description", nil)
+		require.NoError(t, err)
+		err = repo.Create(childCategory)
+		require.NoError(t, err)
+
+		// Verify initial state
+		assert.Nil(t, childCategory.ParentID)
+
+		// Update child to have parent
+		childCategory.ParentID = &parentCategory.ID
+		err = repo.Update(childCategory)
+		require.NoError(t, err)
+
+		// Fetch from database to verify
+		updated, err := repo.GetByID(childCategory.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, updated.ParentID)
+		assert.Equal(t, parentCategory.ID, *updated.ParentID)
+	})
+
+	t.Run("should update ParentID from valid ID to nil using 0", func(t *testing.T) {
+		// Create parent category
+		parentCategory, err := entity.NewCategory("Parent Category 2", "Parent description", nil)
+		require.NoError(t, err)
+		err = repo.Create(parentCategory)
+		require.NoError(t, err)
+
+		// Create child category with parent
+		childCategory, err := entity.NewCategory("Child Category 2", "Child description", &parentCategory.ID)
+		require.NoError(t, err)
+		err = repo.Create(childCategory)
+		require.NoError(t, err)
+
+		// Verify initial state
+		assert.NotNil(t, childCategory.ParentID)
+		assert.Equal(t, parentCategory.ID, *childCategory.ParentID)
+
+		// Update child to remove parent (simulate sending parent_id: 0 from API)
+		childCategory.ParentID = nil
+		err = repo.Update(childCategory)
+		require.NoError(t, err)
+
+		// Fetch from database to verify
+		updated, err := repo.GetByID(childCategory.ID)
+		require.NoError(t, err)
+		assert.Nil(t, updated.ParentID)
+	})
+
+	t.Run("should update ParentID from one valid ID to another", func(t *testing.T) {
+		// Create parent categories
+		parentCategory1, err := entity.NewCategory("Parent Category 3", "Parent description", nil)
+		require.NoError(t, err)
+		err = repo.Create(parentCategory1)
+		require.NoError(t, err)
+
+		parentCategory2, err := entity.NewCategory("Parent Category 4", "Parent description", nil)
+		require.NoError(t, err)
+		err = repo.Create(parentCategory2)
+		require.NoError(t, err)
+
+		// Create child category with first parent
+		childCategory, err := entity.NewCategory("Child Category 3", "Child description", &parentCategory1.ID)
+		require.NoError(t, err)
+		err = repo.Create(childCategory)
+		require.NoError(t, err)
+
+		// Verify initial state
+		assert.NotNil(t, childCategory.ParentID)
+		assert.Equal(t, parentCategory1.ID, *childCategory.ParentID)
+
+		// Update child to have second parent
+		childCategory.ParentID = &parentCategory2.ID
+		err = repo.Update(childCategory)
+		require.NoError(t, err)
+
+		// Fetch from database to verify
+		updated, err := repo.GetByID(childCategory.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, updated.ParentID)
+		assert.Equal(t, parentCategory2.ID, *updated.ParentID)
+	})
+}
+
+func TestCategoryRepository_UpdateParentIDToNil(t *testing.T) {
+	// Setup
+	db := testutil.SetupTestDB(t)
+	defer testutil.CleanupTestDB(t, db)
+
+	repo := NewCategoryRepository(db)
+
+	t.Run("should update ParentID to nil when explicitly set", func(t *testing.T) {
+		// Create parent category
+		parentCategory, err := entity.NewCategory("Parent Category", "Parent description", nil)
+		require.NoError(t, err)
+		err = repo.Create(parentCategory)
+		require.NoError(t, err)
+
+		// Create child category with parent
+		childCategory, err := entity.NewCategory("Child Category", "Child description", &parentCategory.ID)
+		require.NoError(t, err)
+		err = repo.Create(childCategory)
+		require.NoError(t, err)
+
+		// Verify initial state
+		initial, err := repo.GetByID(childCategory.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, initial.ParentID)
+		assert.Equal(t, parentCategory.ID, *initial.ParentID)
+
+		// Update child to remove parent by setting ParentID to nil
+		childCategory.ParentID = nil
+		t.Logf("Before update: childCategory.ParentID = %v", childCategory.ParentID)
+
+		err = repo.Update(childCategory)
+		require.NoError(t, err)
+
+		// Verify the update worked by fetching from database
+		updated, err := repo.GetByID(childCategory.ID)
+		require.NoError(t, err)
+		t.Logf("After update: updated.ParentID = %v", updated.ParentID)
+		assert.Nil(t, updated.ParentID, "ParentID should be nil after update")
+	})
+}


### PR DESCRIPTION
This pull request introduces changes to the category update functionality, focusing on handling the `ParentID` field, ensuring proper database updates, and adding comprehensive tests. The most important changes include modifying the logic to handle `ParentID` as `nil` when set to `0`, improving database update behavior for `ParentID`, and adding tests to validate these behaviors.

### Changes to `ParentID` handling:

* [`internal/application/usecase/category_usecase.go`](diffhunk://#diff-4fd9974a4a27aaf5174fdb8d19c4b01cc16ebb8c3382efc0d7b70c04972313f2L84-R84): Updated `UpdateCategory` logic to interpret `ParentID` as `nil` when set to `0`, ensuring proper removal of parent associations. Added validation to prevent circular references and refetch updated categories to maintain data integrity. [[1]](diffhunk://#diff-4fd9974a4a27aaf5174fdb8d19c4b01cc16ebb8c3382efc0d7b70c04972313f2L84-R84) [[2]](diffhunk://#diff-4fd9974a4a27aaf5174fdb8d19c4b01cc16ebb8c3382efc0d7b70c04972313f2L95-R112) [[3]](diffhunk://#diff-4fd9974a4a27aaf5174fdb8d19c4b01cc16ebb8c3382efc0d7b70c04972313f2L119-R129) [[4]](diffhunk://#diff-4fd9974a4a27aaf5174fdb8d19c4b01cc16ebb8c3382efc0d7b70c04972313f2L137-R158)

### Database update improvements:

* [`internal/infrastructure/repository/gorm/category_repository.go`](diffhunk://#diff-a9b3dd1bbf7204c137ec050baf286414db2acf2037d7980fc19dddfe266bad0aL64-R65): Modified the `Update` method to use explicit field updates (`name`, `description`, `parent_id`) to ensure `ParentID` is correctly updated when set to `nil`.
* [`internal/infrastructure/repository/gorm/category_repository.go`](diffhunk://#diff-a9b3dd1bbf7204c137ec050baf286414db2acf2037d7980fc19dddfe266bad0aL26-R26): Changed the `Delete` method to use `Unscoped` deletes, ensuring soft-deleted categories are removed completely.

### Test additions:

* [`internal/application/usecase/category_usecase_test.go`](diffhunk://#diff-0b7b6bef2addaaad788568f3843b913e4d39d3f940e54c9225970ad2a8c575cdR132-R176): Added a test case `TestCategoryUseCase_UpdateCategory_ParentIDZero` to verify that setting `ParentID` to `0` removes the parent association.
* [`internal/infrastructure/repository/gorm/category_repository_test.go`](diffhunk://#diff-10798f620e992e5819c0c3306ea1350efc1dd20fc5d455cb771cf4ee3107ed88R1-R150): Added multiple test cases to validate `ParentID` updates, including transitions from `nil` to valid IDs, valid IDs to `nil`, and switching between valid IDs.